### PR TITLE
Use the 'upstream' branch on ggtracker/sc2reader

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
--e git+https://github.com/ggtracker/sc2reader.git#egg=sc2reader
+-e git+https://github.com/ggtracker/sc2reader.git@upstream#egg=sc2reader
 -e git+https://github.com/StoicLoofah/spawningtool#egg=spawningtool


### PR DESCRIPTION
The 'master' branch on ggtracker/sc2reader is kept in sync with the out
of date GraylinKim/sc2reader as far as I can tell. Development happens
on the upstream branch.